### PR TITLE
Add .alias File and Update .zshrc

### DIFF
--- a/.alias
+++ b/.alias
@@ -1,0 +1,29 @@
+# Basic Aliases
+alias lsa='ls -al'
+alias cls='clear'
+
+# Docker Aliases
+alias docexec='docker exec'
+alias docexecit='docker exec -it'
+alias docims='docker images'
+alias docopen='open /Applications/Docker.app'
+alias docps='docker ps'
+alias docpsa='docker ps -a'
+alias docstop='docker stop'
+alias docstopall='docker stop $(docker ps -aq)'
+alias docnuke='docker system prune -af --volumes'
+
+# Git Aliases
+alias ga='git add'
+alias gaa='git add -A'
+alias gb='git branch'
+alias gc='git commit'
+alias gcamend='git commit --amend'
+alias gcm='git commit -m'
+alias gd='git diff'
+alias go='git checkout'
+alias golo='git log'
+alias gpl='git pull'
+alias gps='git push'
+alias grpo='git remote prune origin'
+alias gs='git status'

--- a/.zshrc
+++ b/.zshrc
@@ -4,7 +4,6 @@
 
 #-- HOMEBREW --
 # Add Homebrew package management to shell environment
-# Add brew shellenv to your ~/.zshrc file"
 # This is inside baseball from the brew install script
 # Determine where brew itself is installed based on Intel vs Apple Silicon
 [[ `uname -m` == "arm64" ]] && homebrew_prefix="/opt/homebrew" || homebrew_prefix="/usr/local"
@@ -12,33 +11,18 @@ eval "$(${homebrew_prefix}/bin/brew shellenv)"
 unset homebrew_prefix
 
 # -- PACKAGE MANAGERS --
-# For Node Version Manager NVM from homebrew install instructions
-# TODO: Is this correct?
-# export NVM_DIR="$HOME/.nvm"
-# [ -s "/usr/local/opt/nvm/nvm.sh" ] && . "/usr/local/opt/nvm/nvm.sh"
-# [ -s "/usr/local/opt/nvm/etc/bash_completion.d/nvm" ] && . "/usr/local/opt/nvm/etc/bash_completion.d/nvm"
+# Put any nvm, rbenv/rvm, etc config here
 
 # -- UTILITIES (ETC.) --
 # Enable git autocomplete
 autoload -Uz compinit && compinit
 
 # -- ALIASES --
-# Basic Aliases
-alias lsa='ls -al '
-alias cls='clear '
-
-# Git Aliases
-alias ga='git add '
-alias gb='git branch '
-alias gc='git commit '
-alias gcm='git commit -m '
-alias gd='git diff '
-alias go='git checkout '
-alias gs='git status '
-alias golo='git log '
+# If there is a ~/.alias file, source it in to profile
+[[ -f ~/.alias ]] && source ~/.alias
 
 # -- PATH --
-# Nothing yet
+# Put any path modifications here
 
 #--- PROMPT ---
 # Zshell specific includes git branch in prompt
@@ -46,8 +30,7 @@ alias golo='git log '
 parse_git_branch() {
   git branch 2> /dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/ (\1)/'
 }
-# NOTE: PROMPT_SUBST must be set for variable/special character
-# expansion
+# NOTE: PROMPT_SUBST must be set for variable/special character expansion
 setopt PROMPT_SUBST
 # Prompt:username@shorthostname currentdirectoryonly (gitbranchname)%
 PROMPT='%n@%m %1~%F{green}$(parse_git_branch)%f%# '

--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ directory and softlink it to `~/.zshrc`.
    ./install-mac-dev-zsh-profile
    ```
 
+   :fast_forward: To also install the default `~/.alias` file
+   ```bash
+   ./install-mac-dev-zsh-profile -a
+   ```
+
    :hammer: To force the installation and overwrite any existing files
    ```bash
    ./install-mac-dev-zsh-profile -f

--- a/install-mac-dev-zsh-profile
+++ b/install-mac-dev-zsh-profile
@@ -1,55 +1,70 @@
 #!/usr/bin/env bash
-# -----------------------------------------------
-# Installs and softlinks user's .zshrc
-# to ~/<username>-profiles
-# -----------------------------------------------
 
 # Exit script on any errors - exits script from $(subshells)
 set -e
 
-# Get this script's name
-me=$(basename "$0")
+usage() {
+  cat << USAGE
+Usage: $(basename $0) [-afh]
+This script installs and softlinks user's .zshrc to ~/<username>-profiles.
+
+Optionally it can install and softlink a default .alias file as well.
+
+OPTIONS:
+  -a install and link .alias file
+  -f force install and overwrite existing
+  -h help
+USAGE
+}
+
+download_and_link_profile() {
+  profile_file_name=$1
+
+  source_repository=brianjbayer/mac-dev-zsh-profile
+  echo "Installing ${profile_file_name} from ${source_repository}"
+  curl --location --remote-header-name \
+    --remote-name "https://raw.githubusercontent.com/${source_repository}/main/${profile_file_name}"
+
+  # Force the softlink to the profile directory
+  # ln -s -f *source* *new-link*
+  ln -s -f "$(pwd)/${profile_file_name}" "${USER_HOME_DIRECTORY}/${profile_file_name}"
+}
 
 # Command line arguments
-while getopts 'fh' opt; do
+while getopts 'afh' opt; do
   case "$opt" in
 
+    a)
+      install_alias=1
+      ;;
+
     f)
-      force_overwrite="true"
+      force_overwrite=1
       ;;
 
     ?|h)
-      cat << EOF
-Usage: ${me} [-fh]
--f force install and overwrite existing
--h help
-EOF
+      usage
       exit
       ;;
   esac
 done
 shift "$(($OPTIND -1))"
 
-# === MAIN ---
-source_repository=mac-dev-zsh-profile
-echo "Installing .zshrc from ${source_repository}"
-
+# --- MAIN ---
 # Exit early if ~./zshrc exists unless forcing overwriting
 [[ -f ~/.zshrc && -z ${force_overwrite} ]] && (echo " ~/.zshrc exists" ; exit 2)
+# Exit early if ~./alias exists unless forcing overwriting
+[[ -n ${install_alias} && -f ~/.alias && -z ${force_overwrite} ]] && (echo " ~/.alias exists" ; exit 2)
 
 # Install to ~/<username>-profiles
-user_home_directory=$(echo ~)
-profile_dir="${user_home_directory}/$(id -un)-profiles"
+USER_HOME_DIRECTORY=$(echo ~)
+PROFILE_DIR="${USER_HOME_DIRECTORY}/$(id -un)-profiles"
 
 # Make and goto profile directory
-mkdir -p ${profile_dir}
-cd ${profile_dir}
+mkdir -p ${PROFILE_DIR}
+cd ${PROFILE_DIR}
 
+# Install the profile files
+download_and_link_profile .zshrc
 
-# Download the .zshrc file to the profile directory
-curl --location --remote-header-name \
-  --remote-name "https://raw.githubusercontent.com/brianjbayer/${source_repository}/main/.zshrc"
-
-# Force the softlink of profile directory .zshrc to ~/.zshrc
-# ln -s -f *source* *new-link*
-ln -s -f "$(pwd)/.zshrc" "${user_home_directory}/.zshrc"
+[[ -n ${install_alias} ]] && download_and_link_profile .alias


### PR DESCRIPTION
# WHAT & WHY
This moves default aliases from `.zshrc` to a `.alias` file and adds optional installation support.

It also removes comments and cruft from `.zshrc`.

# VERIFICATION
## Installation Script
Adds help option instead of comment
- [x] `./install-mac-dev-zsh-profile -h`

Existing profiles
- [x] `./install-mac-dev-zsh-profile`
- [x] `./install-mac-dev-zsh-profile -a` (verified by commenting out check for `.zshrc`)
- [x]  `./install-mac-dev-zsh-profile -f`
- [x]  `./install-mac-dev-zsh-profile -af`

No Profiles
- [x]  `./install-mac-dev-zsh-profile`
- [x]  `./install-mac-dev-zsh-profile -a`

## Profile files
- [x] Started new terminal verified default profile
- [x] Started new terminal verified aliases 